### PR TITLE
Fix EOF behaviour (protected methods) after MoveBack

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: None
-next-version: 1.0.4
+next-version: 1.0.5
 branches:
   master:
     mode: ContinuousDelivery

--- a/src/Deltics.IO.Text.Unicode.pas
+++ b/src/Deltics.IO.Text.Unicode.pas
@@ -22,11 +22,13 @@ interface
     // IUnicodeReader
     protected
       function IsWhitespace(const aChar: WideChar): Boolean;
+      procedure MoveBack;
       function NextChar: WideChar;
       function NextCharAfter(const aFilter: TWideCharFilterFn): WideChar;
       function NextCharSkippingWhitespace: WideChar;
       function PeekChar: WideChar;
       function PeekCharSkippingWhitespace: WideChar;
+      function ReadLine: UnicodeString;
       procedure Skip(const aNumChars: Integer);
       procedure SkipWhitespace;
       procedure SkipChar;
@@ -45,15 +47,12 @@ interface
       function _ReadNextChar: WideChar;
       procedure DecodeUtf8(const aInputBuffer: Pointer; const aInputBytes: Integer; const aDecodeBuffer: Pointer; const aMaxDecodedBytes: Integer; var aInputBytesDecoded: Integer; var aDecodedBytes: Integer);
       procedure DecodeUtf16(const aInputBuffer: Pointer; const aInputBytes: Integer; const aDecodeBuffer: Pointer; const aMaxDecodedBytes: Integer; var aInputBytesDecoded: Integer; var aDecodedBytes: Integer);
-
     protected
       property EOF: TEofMethod read fActiveEOF;
+      property Location: PCharLocation read fActiveLocation;
       property ReadChar: TWideCharReaderMethod read fActiveReader;
     public
       procedure AfterConstruction; override;
-      procedure MoveBack;
-      function ReadLine: UnicodeString;
-      property Location: PCharLocation read fActiveLocation;
     end;
 
 

--- a/src/Deltics.IO.Text.Utf8.pas
+++ b/src/Deltics.IO.Text.Utf8.pas
@@ -30,6 +30,7 @@ interface
       function NextWideChar: WideChar;
       function PeekChar: Utf8Char;
       function PeekCharSkippingWhitespace: Utf8Char;
+      function ReadLine: Utf8String;
       procedure Skip(const aNumChars: Integer);
       procedure SkipWhitespace;
       procedure SkipChar;
@@ -54,8 +55,9 @@ interface
       function _ReadLoSurrogate: WideChar;
       procedure DecodeUtf16Be(const aInputBuffer: Pointer; const aInputBytes: Integer; const aDecodeBuffer: Pointer; const aMaxDecodedBytes: Integer; var aInputBytesDecoded: Integer; var aDecodedBytes: Integer);
       procedure DecodeUtf16(const aInputBuffer: Pointer; const aInputBytes: Integer; const aDecodeBuffer: Pointer; const aMaxDecodedBytes: Integer; var aInputBytesDecoded: Integer; var aDecodedBytes: Integer);
-
     protected
+      property Location: PCharLocation read fActiveLocation;
+      property EOF: TEofMethod read fActiveEOF;
       property ReadChar: TUtf8CharReaderMethod read fActiveReader;
       property ReadWideChar: TWideCharReaderMethod read fActiveWideCharReader;
     public
@@ -66,8 +68,6 @@ interface
       function PeekRealChar(var aWhitespace: String): Utf8Char; overload;
       procedure SkipWhitespace(var aWhitespace: String); overload;
 *)
-      function ReadLine: Utf8String;
-      property Location: PCharLocation read fActiveLocation;
     end;
 
 
@@ -334,7 +334,7 @@ implementation
 
   function TUtf8Reader._ReadError: Utf8Char;
   begin
-    raise Exception.Create('Reading a Ut8 character is invalid when the reader is in this state (Lo Surrogate expected, following NextWideChar)');
+    raise Exception.Create('Reading a Utf8 character is invalid when the reader is in this state (Lo Surrogate expected, following NextWideChar)');
   end;
 
 

--- a/tests/Test.UnicodeReader.pas
+++ b/tests/Test.UnicodeReader.pas
@@ -26,6 +26,7 @@ interface
       procedure ReadLineReadsBlankLinesWithCRLF;
       procedure ReadLineReadsMultipleLinesWithCR;
       procedure ReadLineReadsMultipleLinesWithCRLF;
+      procedure EOFIsFalseForProtectedMethodsWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
       procedure EOFIsFalseWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
     end;
 
@@ -39,6 +40,27 @@ implementation
 
 
 { UtfReader }
+
+  type TProtectedReader = class(TUnicodeReader);
+
+
+  procedure UnicodeReader.EOFIsFalseForProtectedMethodsWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
+  var
+    src: UnicodeString;
+    sut: TProtectedReader;
+  begin
+    src := 'Test';
+
+    sut := TProtectedReader.Create(src);
+    sut.Skip(4);
+
+    Test('EOF').Assert(sut.EOF).IsTrue;
+
+    sut.MoveBack;
+
+    Test('EOF').Assert(sut.EOF).IsFALSE;
+  end;
+
 
   procedure UnicodeReader.EOFIsFalseWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
   var

--- a/tests/Test.Utf8Reader.pas
+++ b/tests/Test.Utf8Reader.pas
@@ -27,6 +27,7 @@ interface
       procedure ReadLineReadsBlankLinesWithCRLF;
       procedure ReadLineReadsMultipleLinesWithCR;
       procedure ReadLineReadsMultipleLinesWithCRLF;
+      procedure EOFIsFalseForProtectedMethodsWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
       procedure EOFIsFalseWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
     end;
 
@@ -40,6 +41,27 @@ implementation
 
 
 { UtfReader }
+
+  type TProtectedReader = class(TUtf8Reader);
+
+
+  procedure Utf8Reader.EOFIsFalseForProtectedMethodsWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
+  var
+    src: Utf8String;
+    sut: TProtectedReader;
+  begin
+    src := 'Test';
+
+    sut := TProtectedReader.Create(src);
+    sut.Skip(4);
+
+    Test('EOF').Assert(sut.EOF).IsTrue;
+
+    sut.MoveBack;
+
+    Test('EOF').Assert(sut.EOF).IsFALSE;
+  end;
+
 
   procedure Utf8Reader.EOFIsFalseWhenPreviousCharIsCachedAfterMoveBackAtTheEndOfStream;
   var


### PR DESCRIPTION
The previous fix for EOF behavior following a `MoveBack` operation was only effective for public/interfaced EOF.  Protected methods relying on EOF (e.g. NextCharSkippingWhitespace) were still not correct.  This addresses that.